### PR TITLE
Revert the "fix" for issue 5 to comply with FGS rules, i.e. double spaced TOC everywhere.

### DIFF
--- a/ocethesis.cls
+++ b/ocethesis.cls
@@ -1100,11 +1100,11 @@
       \fi
    \fi
    \ifdal@contents@page
-      \setlength{\baselineskip}{1.0ex plus 0.5ex minus 0.2ex}
-      \setlength{\parskip}{1ex plus 0.5ex minus 0.2ex}
+      % \setlength{\baselineskip}{1.0ex plus 0.5ex minus 0.2ex}
+      % \setlength{\parskip}{1ex plus 0.5ex minus 0.2ex}
       \tableofcontents
-      \setlength{\baselineskip}{4ex plus 0.5ex minus 0.2ex}
-      \setlength{\parskip}{0ex plus 0.5ex minus 0.2ex}
+      % \setlength{\baselineskip}{4ex plus 0.5ex minus 0.2ex}
+      % \setlength{\parskip}{0ex plus 0.5ex minus 0.2ex}
       \clearpage
    \else
       \addtocounter{page}{1}


### PR DESCRIPTION
Based on comments to jrconrad from FGS that an acceptable fix to issue
5 is to just make the TOC double spaced everywhere (i.e. even for
section headings that wrap over multiple lines).

It should be noted that in 5 science textbooks that were close at
hand, this is actually how the TOCs were laid out.
