### PR TITLE
fix quotes in `appendix1.tex`

### DIFF
--- a/appendix1.tex
+++ b/appendix1.tex
@@ -5,14 +5,13 @@
 
 	\item Learn about running latex and bibtex -- how many times, and in what order!
 
- \item Examine the .tex file to see how things are done. Note that it's convenient to use the "include{}"
+ \item Examine the .tex file to see how things are done. Note that it's convenient to use the ``include''
 syntax for chapters, so you can check formatting quickly, without processing the entire thesis.
 
-	\item It's a good idea to establish a convention for referencing items, e.g. perhaps "e:..." for
-equations, "f:..." for figures, "t:..." for tables, "c:..." for chapters.
+	\item It's a good idea to establish a convention for referencing items, e.g. perhaps ``e:...'' for
+equations, ``f:...'' for figures, ``t:...'' for tables, ``c:...'' for chapters.
 
-
-	\item Be sure to put the "label" commands inside figure captions. Otherwise (sometimes) cross-referencing will be mixed up.
+	\item Be sure to put the ``label'' commands inside figure captions. Otherwise (sometimes) cross-referencing will be mixed up.
 	
 	\item Note the short-form figure caption, which appears in the list of figures.  (Do this work early because it's a pain later!)
 	
@@ -20,5 +19,11 @@ equations, "f:..." for figures, "t:..." for tables, "c:..." for chapters.
 
  	\item Graphics can be tricky. Do some tests early on, so you'll learn whether your LaTeX setup
     handles the graphs you make. 
+
+  \item Be careful with quotation marks. In latex the \verb|"|-key
+    (i.e. the unidirected double quote character) produces double
+    right quotation marks, and should never be used. Double quotation
+    marks are produced by typing \verb|``| and \verb|''|. Most
+    latex-oriented text editors will do the substitution for you.
 
 \end{itemize}


### PR DESCRIPTION
Hi,

I fixed the quotes in `appendix.tex`, as they all used the " character, which produces double-right quotations. I only thought of this because Janet had asked me about it awhile ago, and I just noticed that in the examples in your Hints appendix, you do it wrong.

I also added an item about it so that people wouldn't be confused.
