### PR TITLE
Create PDF/A file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ DS_Store
 .Rhistory
 _site
 *.dvi
+
+*.out
+*.xmpi

--- a/mythesis.tex
+++ b/mythesis.tex
@@ -13,6 +13,8 @@
 \usepackage{rotating}           % Use this if you have rotated figures
 \usepackage{subfigure}          % Use this if you want sub-figures
 \usepackage{microtype}          % Subtly improves word spacing
+\usepackage[a-1b]{pdfx}         % Create PDF/A file (enter metadata in mythesis.xmpdata)
+\usepackage{hyperref}           % Hyperlinks to cross-references
 
 \parindent=1em                  % Set any value you like
 

--- a/mythesis.xmpdata
+++ b/mythesis.xmpdata
@@ -1,0 +1,91 @@
+% Replace the following information with your document's actual
+% metadata. If you do not want to set a value for a certain parameter,
+% just omit it.
+%
+% Symbols permitted in metadata
+% =============================
+% 
+% Within the metadata, all printable ASCII characters except
+% '\', '{', '}', and '%' represent themselves. Also, all printable
+% Unicode characters from the basic multilingual plane (i.e., up to
+% code point U+FFFF) can be used directly with the UTF-8 encoding. 
+% Consecutive whitespace characters are combined into a single
+% space. Whitespace after a macro such as \copyright, \backslash, or
+% \sep is ignored. Blank lines are not permitted. Moreover, the
+% following markup can be used:
+%
+%  '\ '         - a literal space  (for example after a macro)                  
+%   \%          - a literal '%'                                                 
+%   \{          - a literal '{'                                                 
+%   \}          - a literal '}'                                                 
+%   \backslash  - a literal '\'                                                 
+%   \copyright  - the (c) copyright symbol                                      
+%
+% The macro \sep is only permitted within \Author, \Keywords, and
+% \Org.  It is used to separate multiple authors, keywords, etc.
+% 
+% List of supported metadata fields
+% =================================
+% 
+% Here is a complete list of user-definable metadata fields currently
+% supported, and their meanings. More may be added in the future.
+% 
+% General information:
+%
+%  \Author           - the document's human author. Separate multiple
+%                      authors with \sep.
+%  \Title            - the document's title.
+%  \Keywords         - list of keywords, separated with \sep.
+%  \Subject          - the abstract. 
+%  \Org              - publishers.
+% 
+% Copyright information:
+%
+%  \Copyright        - a copyright statement.
+%  \CopyrightURL     - location of a web page describing the owner
+%                      and/or rights statement for this document.
+%  \Copyrighted      - 'True' if the document is copyrighted, and
+%                      'False' if it isn't. This is automatically set
+%                      to 'True' if either \Copyright or \CopyrightURL
+%                      is specified, but can be overridden. For
+%                      example, if the copyright statement is "Public
+%                      Domain", this should be set to 'False'.
+%
+% Publication information:
+%
+% \PublicationType   - The type of publication. If defined, must be
+%                      one of book, catalog, feed, journal, magazine,
+%                      manual, newsletter, pamphlet. This is
+%                      automatically set to "journal" if \Journaltitle
+%                      is specified, but can be overridden.
+% \Journaltitle      - The title of the journal in which the document
+%                      was published. 
+% \Journalnumber     - The ISSN for the publication in which the
+%                      document was published.
+% \Volume            - Journal volume.
+% \Issue             - Journal issue/number.
+% \Firstpage         - First page number of the published version of
+%                      the document.
+% \Lastpage          - Last page number of the published version of
+%                      the document.
+% \Doi               - Digital Object Identifier (DOI) for the
+%                      document, without the leading "doi:".
+% \CoverDisplayDate  - Date on the cover of the journal issue, as a
+%                      human-readable text string.
+% \CoverDate         - Date on the cover of the journal issue, in a
+%                      format suitable for storing in a database field
+%                      with a 'date' data type.
+
+
+
+\Title        {The Title Goes Here}
+
+\Author       {Your Name Goes Here}
+
+\Copyright    {Copyright \copyright\ 2014 "Author's Name Goes Here"}
+
+\Keywords     {some keyword\sep
+               another keyword\sep
+               some more keywords}
+
+\Subject      {This is where you put the abstract.}


### PR DESCRIPTION
Using the `pdfx` and `hyperref` packages allow for the creation of PDF/A files which seem to be required by FGS. More information [here](http://www.mathstat.dal.ca/~selinger/pdfa/).